### PR TITLE
Added Array.isArray check for the 'A' option

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var types = {
   "*": ["any", function () { return true }],
-  A: ["array", function (thingy) { return thingy instanceof Array || (typeof thingy === "object" && thingy.hasOwnProperty("callee")) }],
+  A: ["array", function (thingy) { return (Array.isArray && Array.isArray(thingy)) || thingy instanceof Array || (typeof thingy === "object" && thingy.hasOwnProperty("callee")) }],
   S: ["string", function (thingy) { return typeof thingy === "string" }],
   N: ["number", function (thingy) { return typeof thingy === "number" }],
   F: ["function", function (thingy) { return typeof thingy === "function" }],


### PR DESCRIPTION
Hi @iarna, 

as you can see I added a new or condition for checking if the element is an array, let me explain with also  the support of two screenshots I made.

I'm using `npm` library inside a nw.js application for managing the installation, the update and the removal of dependencies. When I called the `rm` command I saw a complain about the fact that the first parameter wasn't an array.

In reality that one is an array but I saw this:
![01](https://cloud.githubusercontent.com/assets/1098882/14589625/f3fdc8fe-04e6-11e6-90dd-174acca9acee.png)

Still in debug I tried to call the `Array.isArray` method and the check is passed. 
For double checking I did a debug session of npm cli and everything is ok without complains (I don't undestand why in nw.js enviroment I see this different behavior).

Putting the second check, that is in this PR, in the same scenario everything is as I expected:
![02](https://cloud.githubusercontent.com/assets/1098882/14589651/b44a9aba-04e7-11e6-9aaf-b48ce4c2f913.png)

Best regards,
Dario
